### PR TITLE
Fix triple encoding sign to match Equation (12) in the paper

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -43,7 +43,7 @@ class myTransformer(nn.Module):
         head_emb = self.subject_embedding(head_word_list)
         rel_emb = self.rel_embedding(relation_word_list)
         tail_emb = self.object_embedding(tail_word_list)
-        triple_emb = head_emb + rel_emb + tail_emb
+        triple_emb = head_emb + rel_emb - tail_emb
         knowledge_emb = torch.mean(triple_emb,dim=2)
 
         knowledge_emb = torch.mean(self.transformer(knowledge_emb), dim=1)


### PR DESCRIPTION
This update corrects the implementation of the triple encoder to match the formulation described in Equation (12) of the paper

In the paper, the triple embedding is defined as:

etriple = wh + wr − wt

However, in the current implementation the tail embedding is added instead of subtracted:

triple_emb = head_emb + rel_emb + tail_emb

This pull request changes the implementation to:

triple_emb = head_emb + rel_emb - tail_emb